### PR TITLE
BRNGG-38707 handle empty response from statuscake

### DIFF
--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -300,6 +300,11 @@ func (service *StatusCakeMonitorService) GetAll() ([]models.Monitor, error) {
 			return nil, err
 		}
 
+		if res == nil || res.StatusCakeData == nil {
+			log.Error(errors.New("empty response"), "Got empty response from StatusCake when fetching monitors")
+			return nil, errors.New("empty response")
+		}
+
 		StatusCakeMonitorData = append(StatusCakeMonitorData, res.StatusCakeData...)
 		if page >= res.StatusCakeMetadata.PageCount {
 			break


### PR DESCRIPTION
### **User description**
The controller sometimes gets rate limited (this is a known problem with the controller, not only for StatusCake, many people complain about it. The problem is, that when getting rate when fetching monitors, the API doesn't return an error but simply an empty response. This leads to a nil pointer dereference when reaching this line: `StatusCakeMonitorData = append(StatusCakeMonitorData, res.StatusCakeData...)`

This patch returns an error if the response is empty, thus preventing the code from reaching the problematic part. the controller will continue to reconcile and eventually succeed.


___

### **PR Type**
bug_fix


___

### **Description**
- Added error handling for cases where the StatusCake API returns an empty response.
- Logged an error message when an empty response is encountered to aid in debugging.
- Prevented potential nil pointer dereference by returning an error if the response is empty.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statuscake-monitor.go</strong><dd><code>Handle empty response from StatusCake API to prevent errors</code></dd></summary>
<hr>

pkg/monitors/statuscake/statuscake-monitor.go

<li>Added error handling for empty responses from the StatusCake API.<br> <li> Logged an error message when an empty response is received.<br> <li> Prevented nil pointer dereference by returning an error on empty <br>response.<br>


</details>


  </td>
  <td><a href="https://github.com/bringg/ingress-monitor-controller/pull/7/files#diff-603c7bcf16fedfeeae5a860049d8381c1fa09abad8a423327bd286a95ef7d684">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information